### PR TITLE
fix(postfix): rewrite code, feature is not enabled

### DIFF
--- a/src/scalap/scala/tools/scalap/Decode.scala
+++ b/src/scalap/scala/tools/scalap/Decode.scala
@@ -54,7 +54,7 @@ object Decode {
     import classFile._
 
     classFile annotation SCALA_SIG_ANNOTATION map { case Annotation(_, els) =>
-      val bytesElem = els find (x => constant(x.elementNameIndex) == BYTES_VALUE) orNull
+      val bytesElem = els.find(x => constant(x.elementNameIndex) == BYTES_VALUE).orNull()
       val _bytes    = bytesElem.elementValue match { case ConstValueIndex(x) => constantWrapped(x) }
       val bytes     = _bytes.asInstanceOf[StringBytesPair].bytes
       val length    = ByteCodecs.decode(bytes)


### PR DESCRIPTION
In order that we can emit an error in case a postfix operator is used without enabling the feature as such (see https://github.com/lampepfl/dotty/pull/8388) we need to rewrite the code (alternatively activate the feature)