### PR TITLE
fix Decode, orNull instead of orNull()

### DIFF
--- a/src/scalap/scala/tools/scalap/Decode.scala
+++ b/src/scalap/scala/tools/scalap/Decode.scala
@@ -54,7 +54,7 @@ object Decode {
     import classFile._
 
     classFile annotation SCALA_SIG_ANNOTATION map { case Annotation(_, els) =>
-      val bytesElem = els.find(x => constant(x.elementNameIndex) == BYTES_VALUE).orNull()
+      val bytesElem = els.find(x => constant(x.elementNameIndex) == BYTES_VALUE).orNull
       val _bytes    = bytesElem.elementValue match { case ConstValueIndex(x) => constantWrapped(x) }
       val bytes     = _bytes.asInstanceOf[StringBytesPair].bytes
       val length    = ByteCodecs.decode(bytes)


### PR DESCRIPTION
@smarter sorry, I shouldn't have done #3 on my mobile, I actually made a mistake, it should have been `orNull` and not `orNull()`. This PR fixes this mistake